### PR TITLE
Fix IOE thrown when 'UseStringProtoEnumValueNames' enabled

### DIFF
--- a/src/Protobuf.System.Text.Json/ProtobufConverter.cs
+++ b/src/Protobuf.System.Text.Json/ProtobufConverter.cs
@@ -29,11 +29,14 @@ internal class ProtobufConverter<T> : JsonConverter<T?> where T : class, IMessag
 
         _fields = messageDescriptor.Fields.InDeclarationOrder().Select(fieldDescriptor =>
         {
+            var enumType = jsonProtobufSerializerOptions.UseStringProtoEnumValueNames && fieldDescriptor.FieldType == FieldType.Enum
+                ? fieldDescriptor.EnumType
+                : null;
             var fieldInfo = new FieldInfo
             {
                 Accessor = fieldDescriptor.Accessor,
                 IsRepeated = fieldDescriptor.IsRepeated,
-                EnumType = jsonProtobufSerializerOptions.UseStringProtoEnumValueNames ? fieldDescriptor.EnumType : null,
+                EnumType = enumType,
                 IsMap = fieldDescriptor.IsMap,
                 FieldType = FieldTypeResolver.ResolverFieldType(fieldDescriptor, propertyTypeLookup),
                 JsonName = convertNameFunc(fieldDescriptor),

--- a/test/Protobuf.System.Text.Json.Tests/MessageWithEnumFieldTests.Should_serialize_enum_value_as_number_when_using_proto_value_name_is_not_possible.approved.json
+++ b/test/Protobuf.System.Text.Json.Tests/MessageWithEnumFieldTests.Should_serialize_enum_value_as_number_when_using_proto_value_name_is_not_possible.approved.json
@@ -1,3 +1,4 @@
 ﻿{
-  "enumField": 99
+  "enumField": 99,
+  "regularField": 0
 }

--- a/test/Protobuf.System.Text.Json.Tests/MessageWithEnumFieldTests.Should_serialize_enum_value_using_proto_enum_value_name.approved.json
+++ b/test/Protobuf.System.Text.Json.Tests/MessageWithEnumFieldTests.Should_serialize_enum_value_using_proto_enum_value_name.approved.json
@@ -1,3 +1,4 @@
 ﻿{
-  "enumField": "FIRST_OPTION"
+  "enumField": "FIRST_OPTION",
+  "regularField": 0
 }

--- a/test/Protobuf.System.Text.Json.Tests/MessageWithEnumFieldTests.Should_serialize_message_with_enum_field.approved.json
+++ b/test/Protobuf.System.Text.Json.Tests/MessageWithEnumFieldTests.Should_serialize_message_with_enum_field.approved.json
@@ -1,3 +1,4 @@
 ﻿{
-  "enumField": 1
+  "enumField": 1,
+  "regularField": 0
 }

--- a/test/Protobuf.System.Text.Json.Tests/Protos/message_with_enum.proto
+++ b/test/Protobuf.System.Text.Json.Tests/Protos/message_with_enum.proto
@@ -4,6 +4,7 @@ option csharp_namespace = "System.Text.Json.Protobuf.Tests";
 
 message MessageWithEnum {
   TestEnum enum_field = 1;
+  int32 regular_field = 2;
 }
 
 enum TestEnum {


### PR DESCRIPTION
It closes #60.